### PR TITLE
fix(graphql): Re-export graphql schemas as frontend need them

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Useful packages for manipulating air quality data. Shared between [Sh\*\*t! I Sm
 
 The below packages are used internally in [Sh\*\*t! I Smoke](https://shootismoke.github.io) projects, but if you're interested, feel free to use them.
 
-| Packages                                     | NPM                                                                                                                          | Description                                                                              |
-| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| [`@shootismoke/graphql`](./packages/graphql) | [![npm (scoped)](https://img.shields.io/npm/v/@shootismoke/graphql.svg)](https://www.npmjs.com/package/@shootismoke/graphql) | (Internal) TypeScript types for GraphQL schemas in Sh\*\*t! I Smoke backend and frontend |
+| Packages                                     | NPM                                                                                                                          | Description                                                                 |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [`@shootismoke/graphql`](./packages/graphql) | [![npm (scoped)](https://img.shields.io/npm/v/@shootismoke/graphql.svg)](https://www.npmjs.com/package/@shootismoke/graphql) | (Internal) TypeScript types for GraphQL schemas in Sh\*\*t! I Smoke backend |
 
 ## FAQ
 

--- a/packages/convert/docs/README.md
+++ b/packages/convert/docs/README.md
@@ -1,6 +1,6 @@
-[@shootismoke/convert](README.md) › [Globals](globals.md)
+[@shootismoke/convert - v0.2.0](README.md) › [Globals](globals.md)
 
-# @shootismoke/convert
+# @shootismoke/convert - v0.2.0
 
 [![npm (scoped)](https://img.shields.io/npm/v/@shootismoke/convert.svg)](https://www.npmjs.com/package/@shootismoke/convert)
 [![dependencies Status](https://david-dm.org/shootismoke/common/status.svg?path=packages/convert)](https://david-dm.org/shootismoke/common?path=packages/convert)

--- a/packages/convert/docs/globals.md
+++ b/packages/convert/docs/globals.md
@@ -1,6 +1,6 @@
-[@shootismoke/convert](README.md) › [Globals](globals.md)
+[@shootismoke/convert - v0.2.0](README.md) › [Globals](globals.md)
 
-# @shootismoke/convert
+# @shootismoke/convert - v0.2.0
 
 ## Index
 

--- a/packages/convert/docs/interfaces/_types_.aqi.md
+++ b/packages/convert/docs/interfaces/_types_.aqi.md
@@ -1,4 +1,4 @@
-[@shootismoke/convert](../README.md) › [Globals](../globals.md) › ["types"](../modules/_types_.md) › [Aqi](_types_.aqi.md)
+[@shootismoke/convert - v0.2.0](../README.md) › [Globals](../globals.md) › ["types"](../modules/_types_.md) › [Aqi](_types_.aqi.md)
 
 # Interface: Aqi
 
@@ -27,7 +27,7 @@ An interface to represent an AQI
 
 • **displayName**: *string*
 
-*Defined in [types.ts:8](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/types.ts#L8)*
+*Defined in [types.ts:8](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/types.ts#L8)*
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 • **pollutants**: *[Pollutant](../modules/_util_pollutant_.md#pollutant)[]*
 
-*Defined in [types.ts:10](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/types.ts#L10)*
+*Defined in [types.ts:10](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/types.ts#L10)*
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 • **range**: *[number, number]*
 
-*Defined in [types.ts:11](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/types.ts#L11)*
+*Defined in [types.ts:11](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/types.ts#L11)*
 
 ## Methods
 
@@ -51,7 +51,7 @@ ___
 
 ▸ **fromRaw**(`pollutant`: [Pollutant](../modules/_util_pollutant_.md#pollutant), `raw`: number): *number*
 
-*Defined in [types.ts:9](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/types.ts#L9)*
+*Defined in [types.ts:9](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/types.ts#L9)*
 
 **Parameters:**
 
@@ -68,7 +68,7 @@ ___
 
 ▸ **toRaw**(`pollutant`: [Pollutant](../modules/_util_pollutant_.md#pollutant), `value`: number): *number*
 
-*Defined in [types.ts:12](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/types.ts#L12)*
+*Defined in [types.ts:12](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/types.ts#L12)*
 
 **Parameters:**
 

--- a/packages/convert/docs/interfaces/_util_pollutant_.pollutantmeta.md
+++ b/packages/convert/docs/interfaces/_util_pollutant_.pollutantmeta.md
@@ -1,4 +1,4 @@
-[@shootismoke/convert](../README.md) › [Globals](../globals.md) › ["util/pollutant"](../modules/_util_pollutant_.md) › [PollutantMeta](_util_pollutant_.pollutantmeta.md)
+[@shootismoke/convert - v0.2.0](../README.md) › [Globals](../globals.md) › ["util/pollutant"](../modules/_util_pollutant_.md) › [PollutantMeta](_util_pollutant_.pollutantmeta.md)
 
 # Interface: PollutantMeta
 
@@ -23,7 +23,7 @@ Metadata for each pollutant
 
 • **description**: *string*
 
-*Defined in [util/pollutant.ts:41](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L41)*
+*Defined in [util/pollutant.ts:50](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L50)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • **id**: *[Pollutant](../modules/_util_pollutant_.md#pollutant)*
 
-*Defined in [util/pollutant.ts:39](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L39)*
+*Defined in [util/pollutant.ts:48](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L48)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [util/pollutant.ts:40](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L40)*
+*Defined in [util/pollutant.ts:49](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L49)*
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 • **preferredUnit**: *[Unit](../modules/_util_pollutant_.md#unit)*
 
-*Defined in [util/pollutant.ts:42](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L42)*
+*Defined in [util/pollutant.ts:51](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L51)*

--- a/packages/convert/docs/modules/_aqi_chnmep_chnmep_.md
+++ b/packages/convert/docs/modules/_aqi_chnmep_chnmep_.md
@@ -1,4 +1,4 @@
-[@shootismoke/convert](../README.md) › [Globals](../globals.md) › ["aqi/chnMep/chnMep"](_aqi_chnmep_chnmep_.md)
+[@shootismoke/convert - v0.2.0](../README.md) › [Globals](../globals.md) › ["aqi/chnMep/chnMep"](_aqi_chnmep_chnmep_.md)
 
 # External module: "aqi/chnMep/chnMep"
 
@@ -14,7 +14,7 @@
 
 ### ▪ **chnMep**: *object*
 
-*Defined in [aqi/chnMep/chnMep.ts:9](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/aqi/chnMep/chnMep.ts#L9)*
+*Defined in [aqi/chnMep/chnMep.ts:9](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/aqi/chnMep/chnMep.ts#L9)*
 
 AQI (CN)
 
@@ -24,4 +24,4 @@ AQI (CN)
 
 • **displayName**: *string* = "AQI (CN)"
 
-*Defined in [aqi/chnMep/chnMep.ts:10](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/aqi/chnMep/chnMep.ts#L10)*
+*Defined in [aqi/chnMep/chnMep.ts:10](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/aqi/chnMep/chnMep.ts#L10)*

--- a/packages/convert/docs/modules/_aqi_usaepa_usaepa_.md
+++ b/packages/convert/docs/modules/_aqi_usaepa_usaepa_.md
@@ -1,4 +1,4 @@
-[@shootismoke/convert](../README.md) › [Globals](../globals.md) › ["aqi/usaEpa/usaEpa"](_aqi_usaepa_usaepa_.md)
+[@shootismoke/convert - v0.2.0](../README.md) › [Globals](../globals.md) › ["aqi/usaEpa/usaEpa"](_aqi_usaepa_usaepa_.md)
 
 # External module: "aqi/usaEpa/usaEpa"
 
@@ -14,7 +14,7 @@
 
 ### ▪ **usaEpa**: *object*
 
-*Defined in [aqi/usaEpa/usaEpa.ts:9](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/aqi/usaEpa/usaEpa.ts#L9)*
+*Defined in [aqi/usaEpa/usaEpa.ts:9](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/aqi/usaEpa/usaEpa.ts#L9)*
 
 AQI (US)
 
@@ -24,4 +24,4 @@ AQI (US)
 
 • **displayName**: *string* = "AQI (US)"
 
-*Defined in [aqi/usaEpa/usaEpa.ts:10](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/aqi/usaEpa/usaEpa.ts#L10)*
+*Defined in [aqi/usaEpa/usaEpa.ts:10](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/aqi/usaEpa/usaEpa.ts#L10)*

--- a/packages/convert/docs/modules/_convert_.md
+++ b/packages/convert/docs/modules/_convert_.md
@@ -1,4 +1,4 @@
-[@shootismoke/convert](../README.md) › [Globals](../globals.md) › ["convert"](_convert_.md)
+[@shootismoke/convert - v0.2.0](../README.md) › [Globals](../globals.md) › ["convert"](_convert_.md)
 
 # External module: "convert"
 
@@ -14,7 +14,7 @@
 
 ▸ **convert**<**From**, **To**>(`pollutant`: [Pollutant](_util_pollutant_.md#pollutant), `from`: From, `to`: To, `value`: number): *number*
 
-*Defined in [convert.ts:14](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/convert.ts#L14)*
+*Defined in [convert.ts:14](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/convert.ts#L14)*
 
 For any pollutant, convert an AQI to its raw concentration, or vice versa,
 or convert an AQI to another AQI

--- a/packages/convert/docs/modules/_types_.md
+++ b/packages/convert/docs/modules/_types_.md
@@ -1,4 +1,4 @@
-[@shootismoke/convert](../README.md) › [Globals](../globals.md) › ["types"](_types_.md)
+[@shootismoke/convert - v0.2.0](../README.md) › [Globals](../globals.md) › ["types"](_types_.md)
 
 # External module: "types"
 
@@ -18,6 +18,6 @@
 
 Ƭ **AqiCode**: *keyof "/Users/amaurymartiny/Workspaces/shootismoke/common/packages/convert/src/aqi/index"*
 
-*Defined in [types.ts:18](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/types.ts#L18)*
+*Defined in [types.ts:18](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/types.ts#L18)*
 
 List of AQI codes

--- a/packages/convert/docs/modules/_util_pollutant_.md
+++ b/packages/convert/docs/modules/_util_pollutant_.md
@@ -1,4 +1,4 @@
-[@shootismoke/convert](../README.md) › [Globals](../globals.md) › ["util/pollutant"](_util_pollutant_.md)
+[@shootismoke/convert - v0.2.0](../README.md) › [Globals](../globals.md) › ["util/pollutant"](_util_pollutant_.md)
 
 # External module: "util/pollutant"
 
@@ -21,6 +21,7 @@
 ### Object literals
 
 * [AllPollutants](_util_pollutant_.md#const-allpollutants)
+* [AllUnits](_util_pollutant_.md#const-allunits)
 
 ## Type aliases
 
@@ -28,7 +29,7 @@
 
 Ƭ **Pollutant**: *"co" | "c6h6" | "ox" | "nh3" | "nmhc" | "no" | "nox" | "no2" | "o3" | "pm10" | "pm25" | "so2" | "trs"*
 
-*Defined in [util/pollutant.ts:4](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L4)*
+*Defined in [util/pollutant.ts:4](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L4)*
 
 All the pollutants tracked by @shootismoke
 
@@ -38,7 +39,7 @@ ___
 
 Ƭ **Unit**: *"ppb" | "ppm" | "µg/m³"*
 
-*Defined in [util/pollutant.ts:33](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L33)*
+*Defined in [util/pollutant.ts:42](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L42)*
 
 ## Functions
 
@@ -46,7 +47,7 @@ ___
 
 ▸ **getMetadata**(`pollutant`: [Pollutant](_util_pollutant_.md#pollutant)): *[PollutantMeta](../interfaces/_util_pollutant_.pollutantmeta.md)*
 
-*Defined in [util/pollutant.ts:134](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L134)*
+*Defined in [util/pollutant.ts:143](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L143)*
 
 Get metadata (code, name, unit) for a pollutant
 
@@ -64,7 +65,7 @@ ___
 
 ▸ **isPollutant**(`pollutant`: string): *pollutant is Pollutant*
 
-*Defined in [util/pollutant.ts:144](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L144)*
+*Defined in [util/pollutant.ts:153](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L153)*
 
 Check if the input pollutant is a recognized pollutant which we can convert
 AQI to/from raw concentrations
@@ -83,13 +84,13 @@ Name | Type | Description |
 
 ### ▪ **AllPollutants**: *object*
 
-*Defined in [util/pollutant.ts:48](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L48)*
+*Defined in [util/pollutant.ts:57](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L57)*
 
 All the pollutants tracked by @shootismoke
 
 ▪ **c6h6**: *object*
 
-*Defined in [util/pollutant.ts:55](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L55)*
+*Defined in [util/pollutant.ts:64](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L64)*
 
 * **description**: *string* = "Benzene"
 
@@ -101,7 +102,7 @@ All the pollutants tracked by @shootismoke
 
 ▪ **co**: *object*
 
-*Defined in [util/pollutant.ts:49](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L49)*
+*Defined in [util/pollutant.ts:58](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L58)*
 
 * **description**: *string* = "Carbon monoxide"
 
@@ -113,7 +114,7 @@ All the pollutants tracked by @shootismoke
 
 ▪ **nh3**: *object*
 
-*Defined in [util/pollutant.ts:73](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L73)*
+*Defined in [util/pollutant.ts:82](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L82)*
 
 * **description**: *string* = "Ammonia"
 
@@ -125,7 +126,7 @@ All the pollutants tracked by @shootismoke
 
 ▪ **nmhc**: *object*
 
-*Defined in [util/pollutant.ts:79](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L79)*
+*Defined in [util/pollutant.ts:88](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L88)*
 
 * **description**: *string* = "Non-methane hydrocarbons"
 
@@ -137,7 +138,7 @@ All the pollutants tracked by @shootismoke
 
 ▪ **no**: *object*
 
-*Defined in [util/pollutant.ts:85](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L85)*
+*Defined in [util/pollutant.ts:94](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L94)*
 
 * **description**: *string* = "Nitrogen monoxide"
 
@@ -149,7 +150,7 @@ All the pollutants tracked by @shootismoke
 
 ▪ **no2**: *object*
 
-*Defined in [util/pollutant.ts:97](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L97)*
+*Defined in [util/pollutant.ts:106](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L106)*
 
 * **description**: *string* = "Nitrogen dioxide"
 
@@ -161,7 +162,7 @@ All the pollutants tracked by @shootismoke
 
 ▪ **nox**: *object*
 
-*Defined in [util/pollutant.ts:91](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L91)*
+*Defined in [util/pollutant.ts:100](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L100)*
 
 * **description**: *string* = "Nitrogen oxides"
 
@@ -173,7 +174,7 @@ All the pollutants tracked by @shootismoke
 
 ▪ **o3**: *object*
 
-*Defined in [util/pollutant.ts:67](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L67)*
+*Defined in [util/pollutant.ts:76](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L76)*
 
 * **description**: *string* = "Ozone"
 
@@ -185,7 +186,7 @@ All the pollutants tracked by @shootismoke
 
 ▪ **ox**: *object*
 
-*Defined in [util/pollutant.ts:61](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L61)*
+*Defined in [util/pollutant.ts:70](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L70)*
 
 * **description**: *string* = "Photochemical oxidants"
 
@@ -197,7 +198,7 @@ All the pollutants tracked by @shootismoke
 
 ▪ **pm10**: *object*
 
-*Defined in [util/pollutant.ts:109](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L109)*
+*Defined in [util/pollutant.ts:118](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L118)*
 
 * **description**: *string* = "Inhalable particulate matter (<10µm)"
 
@@ -209,7 +210,7 @@ All the pollutants tracked by @shootismoke
 
 ▪ **pm25**: *object*
 
-*Defined in [util/pollutant.ts:103](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L103)*
+*Defined in [util/pollutant.ts:112](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L112)*
 
 * **description**: *string* = "Fine particulate matter (<2.5µm)"
 
@@ -221,7 +222,7 @@ All the pollutants tracked by @shootismoke
 
 ▪ **so2**: *object*
 
-*Defined in [util/pollutant.ts:115](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L115)*
+*Defined in [util/pollutant.ts:124](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L124)*
 
 * **description**: *string* = "Sulfur dioxide"
 
@@ -233,7 +234,7 @@ All the pollutants tracked by @shootismoke
 
 ▪ **trs**: *object*
 
-*Defined in [util/pollutant.ts:121](https://github.com/shootismoke/common/blob/092361a/packages/convert/src/util/pollutant.ts#L121)*
+*Defined in [util/pollutant.ts:130](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L130)*
 
 * **description**: *string* = "Total reduced sulfur"
 
@@ -242,3 +243,31 @@ All the pollutants tracked by @shootismoke
 * **name**: *string* = "TRS"
 
 * **preferredUnit**: *"µg/m³"* =  ugm3
+
+___
+
+### `Const` AllUnits
+
+### ▪ **AllUnits**: *object*
+
+*Defined in [util/pollutant.ts:36](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L36)*
+
+Pollutant concentration units
+
+###  ppb
+
+• **ppb**: *string*
+
+*Defined in [util/pollutant.ts:37](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L37)*
+
+###  ppm
+
+• **ppm**: *string*
+
+*Defined in [util/pollutant.ts:38](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L38)*
+
+###  ugm3
+
+• **ugm3**: *string*
+
+*Defined in [util/pollutant.ts:39](https://github.com/shootismoke/common/blob/5b392da/packages/convert/src/util/pollutant.ts#L39)*

--- a/packages/dataproviders/docs/globals.md
+++ b/packages/dataproviders/docs/globals.md
@@ -1,6 +1,6 @@
-[@shootismoke/dataproviders](README.md) › [Globals](globals.md)
+[@shootismoke/dataproviders - v0.2.3](README.md) › [Globals](globals.md)
 
-# @shootismoke/dataproviders
+# @shootismoke/dataproviders - v0.2.3
 
 ## Index
 
@@ -12,4 +12,6 @@
 * ["providers/waqi/waqi"](modules/_providers_waqi_waqi_.md)
 * ["types"](modules/_types_.md)
 * ["util/constants"](modules/_util_constants_.md)
+* ["util/dominantPol"](modules/_util_dominantpol_.md)
 * ["util/openaq"](modules/_util_openaq_.md)
+* ["util/stationName"](modules/_util_stationname_.md)

--- a/packages/dataproviders/docs/interfaces/_types_.latlng.md
+++ b/packages/dataproviders/docs/interfaces/_types_.latlng.md
@@ -1,4 +1,4 @@
-[@shootismoke/dataproviders](../README.md) › [Globals](../globals.md) › ["types"](../modules/_types_.md) › [LatLng](_types_.latlng.md)
+[@shootismoke/dataproviders - v0.2.3](../README.md) › [Globals](../globals.md) › ["types"](../modules/_types_.md) › [LatLng](_types_.latlng.md)
 
 # Interface: LatLng
 
@@ -21,7 +21,7 @@ Latitude and longitude object
 
 • **latitude**: *number*
 
-*Defined in [types.ts:9](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/types.ts#L9)*
+*Defined in [types.ts:10](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/types.ts#L10)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 • **longitude**: *number*
 
-*Defined in [types.ts:10](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/types.ts#L10)*
+*Defined in [types.ts:11](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/types.ts#L11)*

--- a/packages/dataproviders/docs/interfaces/_types_.provider.md
+++ b/packages/dataproviders/docs/interfaces/_types_.provider.md
@@ -1,4 +1,4 @@
-[@shootismoke/dataproviders](../README.md) › [Globals](../globals.md) › ["types"](../modules/_types_.md) › [Provider](_types_.provider.md)
+[@shootismoke/dataproviders - v0.2.3](../README.md) › [Globals](../globals.md) › ["types"](../modules/_types_.md) › [Provider](_types_.provider.md)
 
 # Interface: Provider <**DataByGps, DataByStation, Options**>
 
@@ -36,7 +36,7 @@ An interface representing an air quality data provider (fp-ts version)
 
 • **id**: *string*
 
-*Defined in [types.ts:27](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/types.ts#L27)*
+*Defined in [types.ts:33](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/types.ts#L33)*
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [types.ts:28](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/types.ts#L28)*
+*Defined in [types.ts:34](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/types.ts#L34)*
 
 ## Methods
 
@@ -52,7 +52,7 @@ ___
 
 ▸ **fetchByGps**(`gps`: [LatLng](_types_.latlng.md), `options?`: Options): *TaskEither‹Error, DataByGps›*
 
-*Defined in [types.ts:22](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/types.ts#L22)*
+*Defined in [types.ts:28](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/types.ts#L28)*
 
 **Parameters:**
 
@@ -69,7 +69,7 @@ ___
 
 ▸ **fetchByStation**(`stationId`: string, `options?`: Options): *TaskEither‹Error, DataByStation›*
 
-*Defined in [types.ts:23](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/types.ts#L23)*
+*Defined in [types.ts:29](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/types.ts#L29)*
 
 **Parameters:**
 
@@ -84,9 +84,9 @@ ___
 
 ###  normalizeByGps
 
-▸ **normalizeByGps**(`d`: DataByGps): *[Normalized](../modules/_types_.md#normalized)*
+▸ **normalizeByGps**(`d`: DataByGps): *E.Either‹Error, [Normalized](../modules/_types_.md#normalized)›*
 
-*Defined in [types.ts:29](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/types.ts#L29)*
+*Defined in [types.ts:35](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/types.ts#L35)*
 
 **Parameters:**
 
@@ -94,15 +94,15 @@ Name | Type |
 ------ | ------ |
 `d` | DataByGps |
 
-**Returns:** *[Normalized](../modules/_types_.md#normalized)*
+**Returns:** *E.Either‹Error, [Normalized](../modules/_types_.md#normalized)›*
 
 ___
 
 ###  normalizeByStation
 
-▸ **normalizeByStation**(`d`: DataByStation): *[Normalized](../modules/_types_.md#normalized)*
+▸ **normalizeByStation**(`d`: DataByStation): *E.Either‹Error, [Normalized](../modules/_types_.md#normalized)›*
 
-*Defined in [types.ts:30](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/types.ts#L30)*
+*Defined in [types.ts:36](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/types.ts#L36)*
 
 **Parameters:**
 
@@ -110,4 +110,4 @@ Name | Type |
 ------ | ------ |
 `d` | DataByStation |
 
-**Returns:** *[Normalized](../modules/_types_.md#normalized)*
+**Returns:** *E.Either‹Error, [Normalized](../modules/_types_.md#normalized)›*

--- a/packages/dataproviders/docs/interfaces/_types_.providerpromise.md
+++ b/packages/dataproviders/docs/interfaces/_types_.providerpromise.md
@@ -1,4 +1,4 @@
-[@shootismoke/dataproviders](../README.md) › [Globals](../globals.md) › ["types"](../modules/_types_.md) › [ProviderPromise](_types_.providerpromise.md)
+[@shootismoke/dataproviders - v0.2.3](../README.md) › [Globals](../globals.md) › ["types"](../modules/_types_.md) › [ProviderPromise](_types_.providerpromise.md)
 
 # Interface: ProviderPromise <**DataByGps, DataByStation, Options**>
 
@@ -36,7 +36,7 @@ An interface representing an air quality data provider (Promise version)
 
 • **id**: *string*
 
-*Defined in [types.ts:39](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/types.ts#L39)*
+*Defined in [types.ts:45](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/types.ts#L45)*
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [types.ts:40](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/types.ts#L40)*
+*Defined in [types.ts:46](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/types.ts#L46)*
 
 ## Methods
 
@@ -52,7 +52,7 @@ ___
 
 ▸ **fetchByGps**(`gps`: [LatLng](_types_.latlng.md), `options?`: Options): *Promise‹DataByGps›*
 
-*Defined in [types.ts:37](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/types.ts#L37)*
+*Defined in [types.ts:43](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/types.ts#L43)*
 
 **Parameters:**
 
@@ -69,7 +69,7 @@ ___
 
 ▸ **fetchByStation**(`stationId`: string, `options?`: Options): *Promise‹DataByStation›*
 
-*Defined in [types.ts:38](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/types.ts#L38)*
+*Defined in [types.ts:44](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/types.ts#L44)*
 
 **Parameters:**
 
@@ -86,7 +86,7 @@ ___
 
 ▸ **normalizeByGps**(`d`: DataByGps): *[Normalized](../modules/_types_.md#normalized)*
 
-*Defined in [types.ts:41](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/types.ts#L41)*
+*Defined in [types.ts:47](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/types.ts#L47)*
 
 **Parameters:**
 
@@ -102,7 +102,7 @@ ___
 
 ▸ **normalizeByStation**(`d`: DataByStation): *[Normalized](../modules/_types_.md#normalized)*
 
-*Defined in [types.ts:42](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/types.ts#L42)*
+*Defined in [types.ts:48](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/types.ts#L48)*
 
 **Parameters:**
 

--- a/packages/dataproviders/docs/modules/_promise_.md
+++ b/packages/dataproviders/docs/modules/_promise_.md
@@ -1,4 +1,4 @@
-[@shootismoke/dataproviders](../README.md) › [Globals](../globals.md) › ["promise"](_promise_.md)
+[@shootismoke/dataproviders - v0.2.3](../README.md) › [Globals](../globals.md) › ["promise"](_promise_.md)
 
 # External module: "promise"
 
@@ -16,7 +16,7 @@
 
 • **aqicn**: *[ProviderPromise](../interfaces/_types_.providerpromise.md)‹object, object, AqicnOptions›* =  promisifyProvider(aqicnFp)
 
-*Defined in [promise.ts:26](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/promise.ts#L26)*
+*Defined in [promise.ts:32](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/promise.ts#L32)*
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 • **openaq**: *[ProviderPromise](../interfaces/_types_.providerpromise.md)‹object, object, __type›* =  promisifyProvider(openaqFp)
 
-*Defined in [promise.ts:27](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/promise.ts#L27)*
+*Defined in [promise.ts:33](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/promise.ts#L33)*
 
 ___
 
@@ -32,4 +32,4 @@ ___
 
 • **waqi**: *[ProviderPromise](../interfaces/_types_.providerpromise.md)‹object, object, __type›* =  promisifyProvider(waqiFp)
 
-*Defined in [promise.ts:28](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/promise.ts#L28)*
+*Defined in [promise.ts:34](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/promise.ts#L34)*

--- a/packages/dataproviders/docs/modules/_providers_aqicn_aqicn_.md
+++ b/packages/dataproviders/docs/modules/_providers_aqicn_aqicn_.md
@@ -1,4 +1,4 @@
-[@shootismoke/dataproviders](../README.md) › [Globals](../globals.md) › ["providers/aqicn/aqicn"](_providers_aqicn_aqicn_.md)
+[@shootismoke/dataproviders - v0.2.3](../README.md) › [Globals](../globals.md) › ["providers/aqicn/aqicn"](_providers_aqicn_aqicn_.md)
 
 # External module: "providers/aqicn/aqicn"
 
@@ -14,7 +14,7 @@
 
 ### ▪ **aqicn**: *object*
 
-*Defined in [providers/aqicn/aqicn.ts:9](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/aqicn/aqicn.ts#L9)*
+*Defined in [providers/aqicn/aqicn.ts:9](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/aqicn/aqicn.ts#L9)*
 
 **`see`** https://aqicn.org
 
@@ -22,34 +22,34 @@
 
 • **fetchByGps**: *fetchByGps*
 
-*Defined in [providers/aqicn/aqicn.ts:10](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/aqicn/aqicn.ts#L10)*
+*Defined in [providers/aqicn/aqicn.ts:10](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/aqicn/aqicn.ts#L10)*
 
 ###  fetchByStation
 
 • **fetchByStation**: *fetchByStation*
 
-*Defined in [providers/aqicn/aqicn.ts:11](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/aqicn/aqicn.ts#L11)*
+*Defined in [providers/aqicn/aqicn.ts:11](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/aqicn/aqicn.ts#L11)*
 
 ###  id
 
 • **id**: *string* = "aqicn"
 
-*Defined in [providers/aqicn/aqicn.ts:12](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/aqicn/aqicn.ts#L12)*
+*Defined in [providers/aqicn/aqicn.ts:12](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/aqicn/aqicn.ts#L12)*
 
 ###  name
 
 • **name**: *string* = "AQI CN"
 
-*Defined in [providers/aqicn/aqicn.ts:13](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/aqicn/aqicn.ts#L13)*
+*Defined in [providers/aqicn/aqicn.ts:13](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/aqicn/aqicn.ts#L13)*
 
 ###  normalizeByGps
 
 • **normalizeByGps**: *normalize* =  normalize
 
-*Defined in [providers/aqicn/aqicn.ts:14](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/aqicn/aqicn.ts#L14)*
+*Defined in [providers/aqicn/aqicn.ts:14](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/aqicn/aqicn.ts#L14)*
 
 ###  normalizeByStation
 
 • **normalizeByStation**: *normalize* =  normalize
 
-*Defined in [providers/aqicn/aqicn.ts:15](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/aqicn/aqicn.ts#L15)*
+*Defined in [providers/aqicn/aqicn.ts:15](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/aqicn/aqicn.ts#L15)*

--- a/packages/dataproviders/docs/modules/_providers_openaq_openaq_.md
+++ b/packages/dataproviders/docs/modules/_providers_openaq_openaq_.md
@@ -1,4 +1,4 @@
-[@shootismoke/dataproviders](../README.md) › [Globals](../globals.md) › ["providers/openaq/openaq"](_providers_openaq_openaq_.md)
+[@shootismoke/dataproviders - v0.2.3](../README.md) › [Globals](../globals.md) › ["providers/openaq/openaq"](_providers_openaq_openaq_.md)
 
 # External module: "providers/openaq/openaq"
 
@@ -14,40 +14,40 @@
 
 ### ▪ **openaq**: *object*
 
-*Defined in [providers/openaq/openaq.ts:6](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/openaq/openaq.ts#L6)*
+*Defined in [providers/openaq/openaq.ts:6](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/openaq/openaq.ts#L6)*
 
 ###  fetchByGps
 
 • **fetchByGps**: *fetchByGps*
 
-*Defined in [providers/openaq/openaq.ts:7](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/openaq/openaq.ts#L7)*
+*Defined in [providers/openaq/openaq.ts:7](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/openaq/openaq.ts#L7)*
 
 ###  fetchByStation
 
 • **fetchByStation**: *fetchByStation*
 
-*Defined in [providers/openaq/openaq.ts:8](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/openaq/openaq.ts#L8)*
+*Defined in [providers/openaq/openaq.ts:8](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/openaq/openaq.ts#L8)*
 
 ###  id
 
 • **id**: *string* = "openaq"
 
-*Defined in [providers/openaq/openaq.ts:9](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/openaq/openaq.ts#L9)*
+*Defined in [providers/openaq/openaq.ts:9](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/openaq/openaq.ts#L9)*
 
 ###  name
 
 • **name**: *string* = "Open AQ"
 
-*Defined in [providers/openaq/openaq.ts:10](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/openaq/openaq.ts#L10)*
+*Defined in [providers/openaq/openaq.ts:10](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/openaq/openaq.ts#L10)*
 
 ###  normalizeByGps
 
 • **normalizeByGps**: *normalize* =  normalize
 
-*Defined in [providers/openaq/openaq.ts:11](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/openaq/openaq.ts#L11)*
+*Defined in [providers/openaq/openaq.ts:11](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/openaq/openaq.ts#L11)*
 
 ###  normalizeByStation
 
 • **normalizeByStation**: *normalize* =  normalize
 
-*Defined in [providers/openaq/openaq.ts:12](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/openaq/openaq.ts#L12)*
+*Defined in [providers/openaq/openaq.ts:12](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/openaq/openaq.ts#L12)*

--- a/packages/dataproviders/docs/modules/_providers_waqi_waqi_.md
+++ b/packages/dataproviders/docs/modules/_providers_waqi_waqi_.md
@@ -1,4 +1,4 @@
-[@shootismoke/dataproviders](../README.md) › [Globals](../globals.md) › ["providers/waqi/waqi"](_providers_waqi_waqi_.md)
+[@shootismoke/dataproviders - v0.2.3](../README.md) › [Globals](../globals.md) › ["providers/waqi/waqi"](_providers_waqi_waqi_.md)
 
 # External module: "providers/waqi/waqi"
 
@@ -14,7 +14,7 @@
 
 ### ▪ **waqi**: *object*
 
-*Defined in [providers/waqi/waqi.ts:9](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/waqi/waqi.ts#L9)*
+*Defined in [providers/waqi/waqi.ts:12](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/waqi/waqi.ts#L12)*
 
 **`see`** https://wind.waqi.info/
 
@@ -22,38 +22,38 @@
 
 • **fetchByGps**: *fetchByGps*
 
-*Defined in [providers/waqi/waqi.ts:10](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/waqi/waqi.ts#L10)*
+*Defined in [providers/waqi/waqi.ts:13](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/waqi/waqi.ts#L13)*
 
 ###  id
 
 • **id**: *string* = "waqi"
 
-*Defined in [providers/waqi/waqi.ts:14](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/waqi/waqi.ts#L14)*
+*Defined in [providers/waqi/waqi.ts:15](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/waqi/waqi.ts#L15)*
 
 ###  name
 
 • **name**: *string* = "WAQI"
 
-*Defined in [providers/waqi/waqi.ts:15](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/waqi/waqi.ts#L15)*
+*Defined in [providers/waqi/waqi.ts:16](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/waqi/waqi.ts#L16)*
 
 ###  normalizeByGps
 
 • **normalizeByGps**: *normalize* =  normalize
 
-*Defined in [providers/waqi/waqi.ts:16](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/waqi/waqi.ts#L16)*
+*Defined in [providers/waqi/waqi.ts:17](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/waqi/waqi.ts#L17)*
 
 ###  fetchByStation
 
-▸ **fetchByStation**(): *never*
+▸ **fetchByStation**(): *TaskEither‹Error, object›*
 
-*Defined in [providers/waqi/waqi.ts:11](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/waqi/waqi.ts#L11)*
+*Defined in [providers/waqi/waqi.ts:14](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/waqi/waqi.ts#L14)*
 
-**Returns:** *never*
+**Returns:** *TaskEither‹Error, object›*
 
 ###  normalizeByStation
 
-▸ **normalizeByStation**(): *never*
+▸ **normalizeByStation**(): *Left‹Error› | Right‹ArrayOneOrMore‹object & object››*
 
-*Defined in [providers/waqi/waqi.ts:17](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/providers/waqi/waqi.ts#L17)*
+*Defined in [providers/waqi/waqi.ts:18](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/providers/waqi/waqi.ts#L18)*
 
-**Returns:** *never*
+**Returns:** *Left‹Error› | Right‹ArrayOneOrMore‹object & object››*

--- a/packages/dataproviders/docs/modules/_types_.md
+++ b/packages/dataproviders/docs/modules/_types_.md
@@ -1,4 +1,4 @@
-[@shootismoke/dataproviders](../README.md) › [Globals](../globals.md) › ["types"](_types_.md)
+[@shootismoke/dataproviders - v0.2.3](../README.md) › [Globals](../globals.md) › ["types"](_types_.md)
 
 # External module: "types"
 
@@ -18,8 +18,9 @@
 
 ###  Normalized
 
-Ƭ **Normalized**: *[OpenAQ](_util_openaq_.md#openaq)[]*
+Ƭ **Normalized**: *ArrayOneOrMore‹[OpenAQFormat](_util_openaq_.md#openaqformat)›*
 
-*Defined in [types.ts:16](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/types.ts#L16)*
+*Defined in [types.ts:22](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/types.ts#L22)*
 
-Normalized response from all data providers
+Normalized response from all data providers. We guarantee that normalized
+results have at least one element, in the openaq-data-format

--- a/packages/dataproviders/docs/modules/_util_constants_.md
+++ b/packages/dataproviders/docs/modules/_util_constants_.md
@@ -1,4 +1,4 @@
-[@shootismoke/dataproviders](../README.md) › [Globals](../globals.md) › ["util/constants"](_util_constants_.md)
+[@shootismoke/dataproviders - v0.2.3](../README.md) › [Globals](../globals.md) › ["util/constants"](_util_constants_.md)
 
 # External module: "util/constants"
 
@@ -14,7 +14,7 @@
 
 • **ACCURATE_RADIUS**: *15000* = 15000
 
-*Defined in [util/constants.ts:5](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/util/constants.ts#L5)*
+*Defined in [util/constants.ts:5](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/util/constants.ts#L5)*
 
 Radius (in m) from the station/sensor, where we consider the air quality
 measurement to be okay.

--- a/packages/dataproviders/docs/modules/_util_dominantpol_.md
+++ b/packages/dataproviders/docs/modules/_util_dominantpol_.md
@@ -1,0 +1,28 @@
+[@shootismoke/dataproviders - v0.2.3](../README.md) › [Globals](../globals.md) › ["util/dominantPol"](_util_dominantpol_.md)
+
+# External module: "util/dominantPol"
+
+## Index
+
+### Functions
+
+* [dominantPol](_util_dominantpol_.md#dominantpol)
+
+## Functions
+
+###  dominantPol
+
+▸ **dominantPol**(`normalized`: [Normalized](_types_.md#normalized)): *Pollutant*
+
+*Defined in [util/dominantPol.ts:11](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/util/dominantPol.ts#L11)*
+
+From some normalized data, calculate the dominant pollutant, i.e. the
+pollutant that has the highest AQI
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`normalized` | [Normalized](_types_.md#normalized) | The normalized data  |
+
+**Returns:** *Pollutant*

--- a/packages/dataproviders/docs/modules/_util_openaq_.md
+++ b/packages/dataproviders/docs/modules/_util_openaq_.md
@@ -1,4 +1,4 @@
-[@shootismoke/dataproviders](../README.md) › [Globals](../globals.md) › ["util/openaq"](_util_openaq_.md)
+[@shootismoke/dataproviders - v0.2.3](../README.md) › [Globals](../globals.md) › ["util/openaq"](_util_openaq_.md)
 
 # External module: "util/openaq"
 
@@ -6,7 +6,7 @@
 
 ### Type aliases
 
-* [OpenAQ](_util_openaq_.md#openaq)
+* [OpenAQFormat](_util_openaq_.md#openaqformat)
 
 ### Variables
 
@@ -14,11 +14,11 @@
 
 ## Type aliases
 
-###  OpenAQ
+###  OpenAQFormat
 
-Ƭ **OpenAQ**: *t.TypeOf‹IntersectionC›*
+Ƭ **OpenAQFormat**: *t.TypeOf‹IntersectionC›*
 
-*Defined in [util/openaq.ts:97](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/util/openaq.ts#L97)*
+*Defined in [util/openaq.ts:101](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/util/openaq.ts#L101)*
 
 **`see`** https://github.com/openaq/openaq-data-format
 
@@ -28,7 +28,7 @@
 
 • **OpenAQCodec**: *IntersectionC‹[TypeC‹object›, PartialC‹object›]›* =  t.intersection([required, optional])
 
-*Defined in [util/openaq.ts:92](https://github.com/shootismoke/common/blob/092361a/packages/dataproviders/src/util/openaq.ts#L92)*
+*Defined in [util/openaq.ts:96](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/util/openaq.ts#L96)*
 
 An io-ts codec to validate the OpenAQ data format
 

--- a/packages/dataproviders/docs/modules/_util_stationname_.md
+++ b/packages/dataproviders/docs/modules/_util_stationname_.md
@@ -1,0 +1,28 @@
+[@shootismoke/dataproviders - v0.2.3](../README.md) › [Globals](../globals.md) › ["util/stationName"](_util_stationname_.md)
+
+# External module: "util/stationName"
+
+## Index
+
+### Functions
+
+* [stationName](_util_stationname_.md#stationname)
+
+## Functions
+
+###  stationName
+
+▸ **stationName**(`data`: [OpenAQFormat](_util_openaq_.md#openaqformat)): *string*
+
+*Defined in [util/stationName.ts:9](https://github.com/shootismoke/common/blob/5b392da/packages/dataproviders/src/util/stationName.ts#L9)*
+
+Get the name of where the measurement has been done, usually the name of the
+air quality station
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`data` | [OpenAQFormat](_util_openaq_.md#openaqformat) |
+
+**Returns:** *string*

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -1,0 +1,7 @@
+[![npm (scoped)](https://img.shields.io/npm/v/@shootismoke/graphql.svg)](https://www.npmjs.com/package/@shootismoke/graphql)
+[![dependencies Status](https://david-dm.org/shootismoke/common/status.svg?path=packages/graphql)](https://david-dm.org/shootismoke/common?path=packages/graphql)
+[![Maintainability](https://api.codeclimate.com/v1/badges/2d517984b9b528fcd3cd/maintainability)](https://codeclimate.com/github/shootismoke/common/maintainability)
+
+# `@shootismoke/graphql`
+
+Graphql schemas and associated TypeScript typings generated from [`@shootismoke/backend`](https://github.com/shootismoke/backend), made available for frontends.

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -15,12 +15,14 @@
   "scripts": {
     "prebuild": "rimraf lib",
     "build": "tsc -p tsconfig.settings.json",
-    "generate": "graphql-codegen"
+    "generate": "graphql-codegen",
+    "copy-schema": "copyfiles -f ../../../backend/src/schema/* src/schema"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^1.8.2",
     "@graphql-codegen/typescript": "^1.8.2",
     "@graphql-codegen/typescript-resolvers": "^1.8.2",
+    "copyfiles": "^2.1.1",
     "graphql": "^14.5.8"
   },
   "peerDependencies": {

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -1,1 +1,2 @@
+export * from './schema';
 export * from './types';

--- a/packages/graphql/src/schema/README.md
+++ b/packages/graphql/src/schema/README.md
@@ -1,0 +1,3 @@
+# `schema/` folder
+
+This files in this folder are all generated automatically by the `yarn copy-schema` command. They are copy-pasted from the `https://github.com/shootismoke/backend` repository, and exposing them in this package so that frontends can use the correct `graphql` types.

--- a/packages/graphql/src/schema/historyItem.ts
+++ b/packages/graphql/src/schema/historyItem.ts
@@ -1,0 +1,14 @@
+import gql from 'graphql-tag';
+
+export const historyItemSchema = gql`
+  type HistoryItem {
+    _id: ID!
+    measurement: Measurement!
+    userId: ID!
+  }
+
+  input CreateHistoryItemInput {
+    measurement: CreateMeasurementInput!
+    userId: ID!
+  }
+`;

--- a/packages/graphql/src/schema/index.ts
+++ b/packages/graphql/src/schema/index.ts
@@ -1,0 +1,4 @@
+export * from './historyItem';
+export * from './link';
+export * from './measurement';
+export * from './user';

--- a/packages/graphql/src/schema/link.ts
+++ b/packages/graphql/src/schema/link.ts
@@ -1,0 +1,12 @@
+import gql from 'graphql-tag';
+
+export const linkSchema = gql`
+  scalar Date
+
+  type Query {
+    _: Boolean
+  }
+  type Mutation {
+    _: Boolean
+  }
+`;

--- a/packages/graphql/src/schema/measurement.ts
+++ b/packages/graphql/src/schema/measurement.ts
@@ -1,0 +1,89 @@
+import { AllPollutants } from '@shootismoke/convert';
+import gql from 'graphql-tag';
+
+export const measurementSchema = gql`
+  type Attribution {
+    name: String!
+    url: String
+  }
+
+  input AttributionInput {
+    name: String!
+    url: String
+  }
+
+  type AveragingPeriod {
+    value: Float!
+    unit: String!
+  }
+
+  input AveragingPeriodInput {
+    value: Float!
+    unit: String!
+  }
+
+  type LocalDate {
+    local: Date!
+    utc: Date!
+  }
+
+  input LocalDateInput {
+    local: Date!
+    utc: Date!
+  }
+
+  type LatLng {
+    latitude: Float!
+    longitude: Float!
+  }
+
+  input LatLngInput {
+    latitude: Float!
+    longitude: Float!
+  }
+
+  enum Parameter {
+    ${Object.keys(AllPollutants).join('\n')}
+  }
+
+  enum SourceType {
+    government
+    research
+    other
+  }
+
+  type Measurement {
+    _id: ID!
+    attribution: [Attribution!]
+    averagingPeriod: AveragingPeriod
+    city: String!
+    coordinates: LatLng!
+    country: String!
+    date: LocalDate!
+    location: String!
+    mobile: Boolean!
+    parameter: Parameter!
+    sourceName: String!
+    sourceNames: [String!]!
+    sourceType: SourceType!
+    unit: String!
+    value: Float!
+  }
+
+  input CreateMeasurementInput {
+    attribution: [AttributionInput!]
+    averagingPeriod: AveragingPeriodInput
+    city: String!
+    coordinates: LatLngInput!
+    country: String!
+    date: LocalDateInput!
+    location: String!
+    mobile: Boolean!
+    parameter: Parameter!
+    sourceName: String!
+    sourceNames: [String!]
+    sourceType: SourceType!
+    unit: String!
+    value: Float!
+  }
+`;

--- a/packages/graphql/src/schema/user.ts
+++ b/packages/graphql/src/schema/user.ts
@@ -1,0 +1,38 @@
+import gql from 'graphql-tag';
+
+export const userSchema = gql`
+  enum Frequency {
+    never
+    daily
+    weekly
+    monthly
+  }
+
+  type Notifications {
+    frequency: Frequency!
+  }
+
+  type User {
+    _id: ID!
+    expoInstallationId: String!
+    expoPushToken: String
+    history: [HistoryItem]!
+    notifications: Notifications!
+  }
+
+  input NotificationsInput {
+    frequency: Frequency!
+  }
+
+  input CreateUserInput {
+    expoInstallationId: String!
+    expoPushToken: String
+    notifications: NotificationsInput
+  }
+
+  input UpdateUserInput {
+    expoInstallationId: String
+    expoPushToken: String
+    notifications: NotificationsInput
+  }
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3099,6 +3099,18 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copyfiles@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/copyfiles/-/copyfiles-2.1.1.tgz#d430e122d7880f92c45d372208b0af03b0c39db6"
+  integrity sha512-y6DZHve80whydXzBal7r70TBgKMPKesVRR1Sn/raUu7Jh/i7iSLSyGvYaq0eMJ/3Y/CKghwzjY32q1WzEnpp3Q==
+  dependencies:
+    glob "^7.0.5"
+    minimatch "^3.0.3"
+    mkdirp "^0.5.1"
+    noms "0.0.0"
+    through2 "^2.0.1"
+    yargs "^13.2.4"
+
 core-js@^2.4.1:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f"
@@ -4262,7 +4274,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@7.1.6, glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@7.1.6, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -4624,7 +4636,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -5003,6 +5015,11 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -6095,7 +6112,7 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -6362,6 +6379,14 @@ node-pre-gyp@^0.12.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+noms@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/noms/-/noms-0.0.0.tgz#da8ebd9f3af9d6760919b27d9cdc8092a7332859"
+  integrity sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "~1.0.31"
 
 "nopt@2 || 3":
   version "3.0.6"
@@ -7247,6 +7272,16 @@ read@1, read@~1.0.1:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+readable-stream@~1.0.31:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
 readdir-scoped-modules@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz#8d45407b4f870a0dcaebc0e28670d18e74514309"
@@ -7997,6 +8032,11 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -8203,7 +8243,7 @@ throat@^4.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
   integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
 
-through2@^2.0.0, through2@^2.0.2:
+through2@^2.0.0, through2@^2.0.1, through2@^2.0.2:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
   integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
@@ -8855,7 +8895,7 @@ yargs-parser@^7.0.0:
   dependencies:
     camelcase "^4.1.0"
 
-yargs@^13.3.0:
+yargs@^13.2.4, yargs@^13.3.0:
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
   integrity sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==


### PR DESCRIPTION
Schemas canonically live in `@shootismoke/backend`. I added a script `yarn copy-schemas` to copy from `@shootismoke/backend` to this repo.