### PR TITLE
Correct Pollutant Names when Normalizing Data

### DIFF
--- a/packages/dataproviders/src/providers/aqicn/normalize.ts
+++ b/packages/dataproviders/src/providers/aqicn/normalize.ts
@@ -120,7 +120,7 @@ export function normalize(data: ByStation): E.Either<Error, Normalized> {
             date: { local, utc },
             location: stationId,
             mobile: false,
-            parameter: data.dominentpol as Pollutant,
+            parameter: pollutant,
             sourceName: 'aqicn',
             sourceType: 'other',
             value: convert(pollutant, 'usaEpa', 'raw', v),

--- a/packages/dataproviders/src/providers/waqi/normalize.ts
+++ b/packages/dataproviders/src/providers/waqi/normalize.ts
@@ -73,7 +73,7 @@ export function normalize({
         },
         location: `waqi|${data.x}`,
         mobile: false,
-        parameter: data.pol,
+        parameter: data.pol as Pollutant,
         sourceName: 'waqi',
         sourceType: 'other',
         unit: getPollutantMeta(data.pol as Pollutant).preferredUnit,

--- a/packages/dataproviders/src/providers/waqi/normalize.ts
+++ b/packages/dataproviders/src/providers/waqi/normalize.ts
@@ -73,7 +73,7 @@ export function normalize({
         },
         location: `waqi|${data.x}`,
         mobile: false,
-        parameter: pollutant,
+        parameter: data.pol,
         sourceName: 'waqi',
         sourceType: 'other',
         unit: getPollutantMeta(data.pol as Pollutant).preferredUnit,

--- a/packages/dataproviders/src/providers/waqi/normalize.ts
+++ b/packages/dataproviders/src/providers/waqi/normalize.ts
@@ -73,7 +73,7 @@ export function normalize({
         },
         location: `waqi|${data.x}`,
         mobile: false,
-        parameter: data.pol as Pollutant,
+        parameter: pollutant,
         sourceName: 'waqi',
         sourceType: 'other',
         unit: getPollutantMeta(data.pol as Pollutant).preferredUnit,


### PR DESCRIPTION
Normalizing data set the dominant pollutant as the name of every pollutant.