### PR TITLE
fix(ui): Allow aqicn & openaq options in race

### DIFF
--- a/packages/ui/src/util/race.ts
+++ b/packages/ui/src/util/race.ts
@@ -20,12 +20,12 @@ import {
 	ProviderPromise,
 } from '@shootismoke/dataproviders';
 import { aqicn, openaq } from '@shootismoke/dataproviders/lib/promise';
+import { OpenAQOptions } from '@shootismoke/dataproviders/lib/providers/openaq/fetchBy';
 import promiseAny, { AggregateError } from 'p-any';
 import debug from 'debug';
 
 import { Api } from './api';
 import { pm25ToCigarettes } from './secretSauce';
-import { OpenAQOptions } from '@shootismoke/dataproviders/lib/providers/openaq/fetchBy';
 
 const l = debug('shootismoke:ui:race');
 

--- a/packages/ui/src/util/race.ts
+++ b/packages/ui/src/util/race.ts
@@ -25,6 +25,7 @@ import debug from 'debug';
 
 import { Api } from './api';
 import { pm25ToCigarettes } from './secretSauce';
+import { OpenAQOptions } from '@shootismoke/dataproviders/lib/providers/openaq/fetchBy';
 
 const l = debug('shootismoke:ui:race');
 
@@ -72,10 +73,13 @@ async function fetchForProvider<DataByGps, DataByStation, Options>(
  * Options to be passed into the {@link raceApiPromise} function.
  */
 interface RaceApiOptions {
-	/**
-	 * The token for fetching aqicn data.
-	 */
-	aqicnToken: string;
+	aqicn?: {
+		/**
+		 * The token for fetching aqicn data.
+		 */
+		aqicnToken?: string;
+	};
+	openaq?: OpenAQOptions;
 }
 
 /**
@@ -91,9 +95,9 @@ export function raceApiPromise(
 	// Run these tasks parallely
 	const tasks = [
 		fetchForProvider(gps, aqicn, {
-			token: options.aqicnToken,
+			token: options.aqicn?.aqicnToken,
 		}).then(filterPm25),
-		fetchForProvider(gps, openaq).then(filterPm25),
+		fetchForProvider(gps, openaq, options.openaq).then(filterPm25),
 	];
 
 	return promiseAny(tasks).catch((errors: AggregateError) => {


### PR DESCRIPTION
BREAKING CHANGE:

The `raceApiPromise` function's 2nd argument, `RaceApiOptions`, now is an object with 2 optional fields: `aqicn` and `openaq`, where each field represents the options to pass down to the respective dataprovider.