### PR TITLE
fix: Fix british columbia type from AQICN

### DIFF
--- a/packages/dataproviders/src/providers/aqicn/sanitized.json
+++ b/packages/dataproviders/src/providers/aqicn/sanitized.json
@@ -5,6 +5,7 @@
 	"liege": "belgium",
 
 	"british-columbia": "canada",
+	"british-comlumbia": "canada",
 	"toronto": "canada",
 
 	"anhui": "china",


### PR DESCRIPTION
In our AQICN sanitization code, we get the country name from its region. For example, the link https://aqicn.org/city/british-comlumbia/castlegar-zinio-park/ only gives British Columbia, and from it we derive Canada.

It seems however that there's a typo in the AQICN API, so we fix the sanitization algorithm to cater to it.